### PR TITLE
When using scanStartPath, resolvePath is now used in the replace.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -375,7 +375,7 @@ export default class VitePressSidebar {
             if (options.scanStartPath) {
               childItemPathDisplay = childItemPathDisplay.replace(
                 new RegExp(`^${options.scanStartPath}`, 'g'),
-                ''
+                options.resolvePath ?? ''
               );
             }
 


### PR DESCRIPTION
Tried to fix this issue:  https://github.com/jooy2/vitepress-sidebar/issues/164 