### PR TITLE
Add end-slash for convert same name sub file based URLs

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -447,7 +447,7 @@ export default class VitePressSidebar {
               );
 
               if (options.folderLinkNotIncludesFileName) {
-                withDirectoryLink = childItemPathDisplay;
+                withDirectoryLink = childItemPathDisplay + '/';
               } else {
                 withDirectoryLink = findItem.link;
               }


### PR DESCRIPTION
**Context**
I want the sub-file of a folder with the same name to act as the index file.
I enable `convertSameNameSubFileToGroupIndexPage` and a corresponding rewrites rule.

**Expected behavior**
```
/foo/bar/bar.md -> /foo/bar/index.md
Final URL: localhost/foo/bar/
```

**Before fix**
Not sure, but I think vitepress-sidebar renamed without end-slash, conflicting with vitepress which expect a end-slash; resulting on broken prev-next links and active class on sidebar.

```
vitepress-sidebar convertion: localhost/foo/bar
vitepress expected path: localhost/foo/bar/
```

**Fix**
It just add an ending slash. Doesn't seem to break anything else, at least with my current config.