### PR TITLE
fix: `sortMenusByFrontmatterOrder` not been sorted in numerical order but in string order

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -618,7 +618,8 @@ export default class VitePressSidebar {
       sidebarItems = VitePressSidebar.sortByObjectKey({
         arr: sidebarItems,
         key: 'order',
-        desc: options.sortMenusOrderByDescending
+        desc: options.sortMenusOrderByDescending,
+        numerically: true
       });
 
       VitePressSidebar.deepDeleteKey(sidebarItems, 'order');

--- a/test/resources/frontmatter-basic/a.md
+++ b/test/resources/frontmatter-basic/a.md
@@ -1,6 +1,6 @@
 ---
 title: A Frontmatter
-order: 4
+order: 10
 date: 2023-01-05
 author: cdget.com
 exclude: true


### PR DESCRIPTION
The behavior inconsistent with documentation:

> Sorts the menu items by the order property of the frontmatter. For each folder, sorts the value **(number)** of the order property in ascending order, or descending order if the sortMenusOrderByDescending option is true. If the value of order is non-numeric or does not exist, order is judged to be 0.

The test samples are also unreasonable. Using `1 2 3 4` as samples will not be able to detect this error.