### PR TITLE
docs: Change Link to Address

### DIFF
--- a/docs/zhHans/guide/getting-started.md
+++ b/docs/zhHans/guide/getting-started.md
@@ -156,7 +156,7 @@ export default defineConfig(
   withSidebar(vitePressConfigs, {
     /*
      * 有关详细说明，请参阅下面的链接：
-     * https://vitepress-sidebar.cdget.com/guide/options
+     * https://vitepress-sidebar.cdget.com/zhHans/guide/options
      */
     //
     // ============ [ RESOLVING PATHS ] ============


### PR DESCRIPTION
### What did you change?
Considering that the current document is read by Chinese users, change this link address to the Chinese document address