### PR TITLE
docs: add VitePress rewrites link and examples to `folderLinkNotIncludesFileName`

### DIFF
--- a/docs/en/guide/options.md
+++ b/docs/en/guide/options.md
@@ -460,7 +460,9 @@ A link is added to the `api` folder, and the `api` page in the `api` folder is n
 - Type: `boolean`
 - Default: `false`
 
-This option is only used in special cases: when you have a rewrite rule and a subfile with the same folder name exists, use it in parallel with the `useFolderLinkFromSameNameSubFile` option.
+This option is only used in special cases: when you have a [rewrite](https://vitepress.dev/guide/routing#route-rewrites) rule and a subfile with the same folder name exists, use it in parallel with the `useFolderLinkFromSameNameSubFile` option.
+
+**Note:** If you enable this option without configuring VitePress rewrites, clicking folder links will result in a 404 error. Make sure to set up the corresponding rewrite rules in your VitePress config.
 
 If this value is `true`, when establishing a folder link, ignore the existence of child items and specify the link only as a folder path.
 
@@ -478,6 +480,27 @@ docs/
 ```
 
 With the `useFolderLinkFromSameNameSubFile` option, clicking on the guide/api folder menu will take you to `guide/api/api`, but if you use the `folderLinkNotIncludesFileName` option with it, the link will be `guide/api/`.
+
+To make this work, you need to configure VitePress rewrites to map the folder path to the actual file. Add the following to your `.vitepress/config.ts`:
+
+```typescript
+export default defineConfig({
+  rewrites: {
+    'guide/api/api.md': 'guide/api/index.md'
+  }
+});
+```
+
+Or use a dynamic rewrite function for multiple folders:
+
+```typescript
+export default defineConfig({
+  rewrites(id) {
+    // Rewrites 'folder/folder.md' to 'folder/index.md'
+    return id.replace(/([^/]+)\/\1\.md$/, '$1/index.md');
+  }
+});
+```
 
 ## `keepMarkdownSyntaxFromTitle`
 

--- a/docs/ko/guide/options.md
+++ b/docs/ko/guide/options.md
@@ -460,7 +460,9 @@ docs/
 - Type: `boolean`
 - Default: `false`
 
-이 옵션은 특별한 경우에만 사용됩니다. 다시 쓰기 규칙이 있고 폴더 이름이 같은 하위 파일이 있는 경우 `useFolderLinkFromSameNameSubFile` 옵션과 병렬로 사용합니다.
+이 옵션은 특별한 경우에만 사용됩니다. [rewrite](https://vitepress.dev/guide/routing#route-rewrites) 규칙이 있고 폴더 이름이 같은 하위 파일이 있는 경우 `useFolderLinkFromSameNameSubFile` 옵션과 병렬로 사용합니다.
+
+**참고:** VitePress rewrites를 설정하지 않고 이 옵션을 활성화하면 폴더 링크를 클릭할 때 404 오류가 발생합니다. VitePress 설정에서 해당 rewrite 규칙을 반드시 설정하세요.
 
 이 값이 `true`인 경우 폴더 링크를 설정할 때 하위 항목의 존재를 무시하고 링크를 폴더 경로로만 지정합니다.
 
@@ -478,6 +480,27 @@ docs/
 ```
 
 `useFolderLinkFromSameNameSubFile` 옵션을 사용하면 `guide/api` 폴더 메뉴를 클릭하면 `guide/api/api`로 이동하지만 `folderLinkNotIncludesFileName` 옵션을 함께 사용하면 `guide/api/`로 링크가 연결됩니다.
+
+이 기능이 작동하려면 VitePress rewrites를 설정하여 폴더 경로를 실제 파일에 매핑해야 합니다. `.vitepress/config.ts`에 다음을 추가하세요:
+
+```typescript
+export default defineConfig({
+  rewrites: {
+    'guide/api/api.md': 'guide/api/index.md'
+  }
+});
+```
+
+또는 여러 폴더에 대해 동적 rewrite 함수를 사용할 수 있습니다:
+
+```typescript
+export default defineConfig({
+  rewrites(id) {
+    // 'folder/folder.md'를 'folder/index.md'로 다시 작성합니다
+    return id.replace(/([^/]+)\/\1\.md$/, '$1/index.md');
+  }
+});
+```
 
 ## `keepMarkdownSyntaxFromTitle`
 

--- a/docs/zhHans/guide/options.md
+++ b/docs/zhHans/guide/options.md
@@ -460,7 +460,9 @@ docs/
 - Type: `boolean`
 - Default: `false`
 
-此选项仅在特殊情况下使用：当您有重写规则并且存在具有相同文件夹名称的子文件时，请将其与 `useFolderLinkFromSameNameSubFile` 选项并行使用。
+此选项仅在特殊情况下使用：当您有 [rewrite](https://vitepress.dev/guide/routing#route-rewrites) 规则并且存在具有相同文件夹名称的子文件时，请将其与 `useFolderLinkFromSameNameSubFile` 选项并行使用。
+
+**注意：** 如果您在未配置 VitePress rewrites 的情况下启用此选项，点击文件夹链接将导致 404 错误。请确保在您的 VitePress 配置中设置相应的 rewrite 规则。
 
 如果此值为 `true`，则在建立文件夹链接时，忽略子项的存在，并仅将链接指定为文件夹路径。
 
@@ -478,6 +480,27 @@ docs/
 ```
 
 使用 `useFolderLinkFromSameNameSubFile` 选项，单击 guide/api 文件夹菜单将带您进入 `guide/api/api`，但如果您使用 `folderLinkNotIncludesFileName` 选项，则链接将为 `guide/api/`。
+
+要使此功能正常工作，您需要配置 VitePress rewrites 将文件夹路径映射到实际文件。在您的 `.vitepress/config.ts` 中添加以下内容：
+
+```typescript
+export default defineConfig({
+  rewrites: {
+    'guide/api/api.md': 'guide/api/index.md'
+  }
+});
+```
+
+或者使用动态 rewrite 函数来处理多个文件夹：
+
+```typescript
+export default defineConfig({
+  rewrites(id) {
+    // 将 'folder/folder.md' 重写为 'folder/index.md'
+    return id.replace(/([^/]+)\/\1\.md$/, '$1/index.md');
+  }
+});
+```
 
 ## `keepMarkdownSyntaxFromTitle`
 


### PR DESCRIPTION
### What did you change?

Updated the `folderLinkNotIncludesFileName` option documentation in all three languages (en, ko, zhHans):

- Added a link to VitePress rewrites documentation
- Added a note about 404 errors when rewrites are not configured
- Added example rewrite configurations

### Why did you make the change?

While using this option, I realized that a direct link to VitePress rewrites documentation and some configuration examples would be helpful for users who are not familiar with the rewrite feature.

Related to #224, #189

### How does this work?

Documentation-only change. No code changes.
