### PR TITLE
fix: use real numeric comparison for sortByObjectKey numeric fields (fixes #233)

### DIFF
--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -398,7 +398,18 @@ export function sortByObjectKey(options: SortByObjectKeyOptions): object[] {
       item[options.key] ?? (options.fallbackKey ? item[options.fallbackKey] : undefined);
 
     result = options.arr.sort((a: SidebarListItem, b: SidebarListItem) => {
-      const compareResult = basicCollator.compare(valueOf(a), valueOf(b));
+      const aValue = valueOf(a);
+      const bValue = valueOf(b);
+      // `Intl.Collator`'s `numeric` option is a natural sort for digit runs
+      // embedded in strings (e.g. filenames): it has no concept of a leading
+      // `-` as a sign or `.` as a decimal point, so it mis-sorts genuinely
+      // numeric values such as frontmatter `order` (-0.5 ends up before -1).
+      // Values that are already numbers (as `order` is, via `parseFloat`)
+      // get real numeric comparison instead.
+      const compareResult =
+        typeof aValue === 'number' && typeof bValue === 'number'
+          ? aValue - bValue
+          : basicCollator.compare(aValue, bValue);
 
       return options.desc ? -compareResult : compareResult;
     });

--- a/test/resources/frontmatter-order-with-negative/a.md
+++ b/test/resources/frontmatter-order-with-negative/a.md
@@ -1,0 +1,8 @@
+---
+title: A Frontmatter
+order: -2
+date: 2023-01-01
+author: cdget.com
+---
+
+# A File

--- a/test/resources/frontmatter-order-with-negative/b.md
+++ b/test/resources/frontmatter-order-with-negative/b.md
@@ -1,0 +1,8 @@
+---
+title: B Frontmatter
+order: -1
+date: 2023-01-02
+author: cdget.com
+---
+
+# B File

--- a/test/resources/frontmatter-order-with-negative/c.md
+++ b/test/resources/frontmatter-order-with-negative/c.md
@@ -1,0 +1,8 @@
+---
+title: C Frontmatter
+order: -0.5
+date: 2023-01-03
+author: cdget.com
+---
+
+# C File

--- a/test/resources/frontmatter-order-with-negative/d.md
+++ b/test/resources/frontmatter-order-with-negative/d.md
@@ -1,0 +1,8 @@
+---
+title: D Frontmatter
+order: 0
+date: 2023-01-04
+author: cdget.com
+---
+
+# D File

--- a/test/resources/frontmatter-order-with-negative/e.md
+++ b/test/resources/frontmatter-order-with-negative/e.md
@@ -1,0 +1,8 @@
+---
+title: E Frontmatter
+order: 1
+date: 2023-01-05
+author: cdget.com
+---
+
+# E File

--- a/test/specs/options.test.ts
+++ b/test/specs/options.test.ts
@@ -942,6 +942,37 @@ describe('Test: APIs', () => {
     );
   });
 
+  it('API: sortMenusByFrontmatterOrder (C: negative and decimal orders)', () => {
+    assert.deepEqual(
+      generateSidebar({
+        documentRootPath: `${TEST_DIR_BASE}/frontmatter-order-with-negative`,
+        sortMenusByFrontmatterOrder: true
+      }),
+      [
+        {
+          text: 'a',
+          link: '/a'
+        },
+        {
+          text: 'b',
+          link: '/b'
+        },
+        {
+          text: 'c',
+          link: '/c'
+        },
+        {
+          text: 'd',
+          link: '/d'
+        },
+        {
+          text: 'e',
+          link: '/e'
+        }
+      ]
+    );
+  });
+
   it('API: sortMenusByFileCreateDate', async () => {
     const targetDir = `${TEST_DIR_BASE}/modify-date`;
 


### PR DESCRIPTION
Intl.Collator's numeric option is a natural sort for digit runs in strings, not a signed/decimal-aware numeric comparator: order: -1 sorted before order: -2, and -0.5 sorted before -1. Compare as numbers when both values already are numbers (as frontmatter order is), keep the collator for the string fields it's meant for (name/title/link natural sort).

Fixes #233 
<!--
Thank you for contributing to the project. Your contribution will be reviewed and approved after appropriate review.

Please read the caveats below to ensure a fast merge.
-->

## Pull request checklist

You should familiarize yourself with the files `README.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` in the root of your project.

- If an issue has been created for this, add `(fixes #{ISSUE_NUMBER})` to the end of the commit description. In `{ISSUE_NUMBER}`, please include the relevant issue number.
- If you need to update or add to the article, please update the relevant content. If a multilingual article exists, you should update all relevant content in your own language, except for translations.
- Add or update test code if it exists and is needed. Also, verify that the tests pass.
- If this PR is not yet complete, keep the PR in draft status. If it's no longer valid, close the PR with an explanation.

<!--
Below is a template for describing this PR. It's not required, so please delete the content below if you don't need it.
-->

### What did you change?

### Why did you make the change?

### How does this work?
